### PR TITLE
Added Swissgerman to Jomres

### DIFF
--- a/libraries/jomres/classes/jomres_language.class.php
+++ b/libraries/jomres/classes/jomres_language.class.php
@@ -179,6 +179,7 @@ class jomres_language
         $langs[ 'en-GB' ] = 'English';
         $langs[ 'cs-CZ' ] = 'Czech';
         $langs[ 'da-DK' ] = 'Dansk';
+        $langs[ 'de-CH' ] = 'Deutsch Schweiz';
         $langs[ 'de-DE' ] = 'Deutsch';
         $langs[ 'el-GR' ] = 'Ελληνικά';
         $langs[ 'en-CA' ] = 'Canadian';
@@ -230,6 +231,7 @@ class jomres_language
         $langs[ 'ar' ] = 'ar-AR';
         $langs[ 'bg' ] = 'bg-BG';
         $langs[ 'en' ] = 'en-GB';
+        $langs[ 'ch' ] = 'de-CH';
         $langs[ 'cs' ] = 'cs-CZ';
         $langs[ 'da' ] = 'da-DK';
         $langs[ 'de' ] = 'de-DE';
@@ -276,6 +278,7 @@ class jomres_language
         $langs[ 'en-GB' ] = 'en-GB';
         $langs[ 'cs-CZ' ] = 'cs';
         $langs[ 'da-DK' ] = 'da';
+        $langs[ 'de-CH' ] = 'de-CH';
         $langs[ 'de-DE' ] = 'de';
         $langs[ 'el-GR' ] = 'el';
         $langs[ 'en-CA' ] = 'en-GB';


### PR DESCRIPTION
Added de-CH to jomres.
Hopefully did it right with function define_langfile_to_datepicker_files_array() in file
/jomres/libraries/jomres/classes/jomres_language.class.php

Copied de-DE.php file to de-CH.php
Swissgerman (language/de-CH.php) is the same as German(language/de-DE.php) and could be cloned

Added Lines on Linenumber 2182-2183:
jr_define( '_JOMRES_PROPERTY_HCATEGORIES', 'Unterkunft Kategorien' );
jr_define( '_JOMRES_PROPERTY_HCATEGORIES_HEDIT', 'Bearbeiten der Unterkunfts-Kategorien' );